### PR TITLE
Issue #4 toolchain bootstrapping

### DIFF
--- a/boot/Memory.c
+++ b/boot/Memory.c
@@ -401,11 +401,8 @@ EFI_STATUS EFIAPI SetupKernelPageTables(IN PAGE_DESCRIPTOR *Descriptors, OUT UIN
     UINT64 PhysAddr = KernelDescriptor->PhysAddr;
     UINTN NumPages = KernelDescriptor->NumPages;
     UINT16 Flags = PageDescriptorFlagsToEntryFlags(KernelDescriptor->Flags) | PE_P;
-    // Declaration before label to avoid clang error
-    // error: label followed by a declaration is a C23 extension
-    UINTN N;
-  FILL:
-    N = MIN(NumPages, TABLE_MAX_ENTRIES - PTOffset);
+  FILL:;
+    UINTN N = MIN(NumPages, TABLE_MAX_ENTRIES - PTOffset);
     if (N > 0)
       FillTableWithEntries(UpperPTs[Index], PTOffset, N, PhysAddr, SIZE_4KB, Flags);
     NumPages -= N;

--- a/boot/Memory.c
+++ b/boot/Memory.c
@@ -401,9 +401,11 @@ EFI_STATUS EFIAPI SetupKernelPageTables(IN PAGE_DESCRIPTOR *Descriptors, OUT UIN
     UINT64 PhysAddr = KernelDescriptor->PhysAddr;
     UINTN NumPages = KernelDescriptor->NumPages;
     UINT16 Flags = PageDescriptorFlagsToEntryFlags(KernelDescriptor->Flags) | PE_P;
-
+    // Declaration before label to avoid clang error
+    // error: label followed by a declaration is a C23 extension
+    UINTN N;
   FILL:
-    UINTN N = MIN(NumPages, TABLE_MAX_ENTRIES - PTOffset);
+    N = MIN(NumPages, TABLE_MAX_ENTRIES - PTOffset);
     if (N > 0)
       FillTableWithEntries(UpperPTs[Index], PTOffset, N, PhysAddr, SIZE_4KB, Flags);
     NumPages -= N;

--- a/configure
+++ b/configure
@@ -72,12 +72,10 @@ check_dependency "llvm-ar" "llvm"
 check_dependency "nasm"
 check_dependency "mformat" "mtools"
 check_dependency "iasl"
-check_dependency "unzip"
 check_dependency "wget"
 check_dependency "python"
 check_dependency "perl"
 check_dependency "qemu-system-${ARCH}"
-check_dependency "iasl"
 
 # autoconf version check
 if check_command "autoconf"; then
@@ -122,7 +120,7 @@ fi
 PROJECT_DIR="$(pwd)"
 
 # defaults
-BUILD_DIR="$(realpath "$BUILD_DIR")"
+BUILD_DIR="$BUILD_DIR/build"
 TOOL_ROOT="$BUILD_DIR/toolchain"
 SYS_ROOT="$BUILD_DIR/sysroot"
 TOOLCHAIN="$ARCH-linux-musl"

--- a/configure
+++ b/configure
@@ -77,6 +77,7 @@ check_dependency "wget"
 check_dependency "python"
 check_dependency "perl"
 check_dependency "qemu-system-${ARCH}"
+check_dependency "iasl"
 
 # autoconf version check
 if check_command "autoconf"; then

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -63,16 +63,18 @@ GCC_PREFIX = $(TOOL_ROOT)
 
 GCC_CONFIG = --enable-languages=c,c++ \
 	--target=$(TOOLCHAIN) \
-    --prefix=$(GCC_PREFIX) \
-    --srcdir=$(GCC_SRC_DIR) \
-    --with-sysroot=$(TOOL_ROOT) \
-    --with-build-sysroot=$(TOOL_ROOT) \
+	--prefix=$(GCC_PREFIX) \
+	--srcdir=$(GCC_SRC_DIR) \
+	--with-sysroot=$(TOOL_ROOT) \
+	--with-build-sysroot=$(TOOL_ROOT) \
+	--enable-shared \
 	--disable-bootstrap --disable-multilib \
- 	--disable-libmpx --disable-libmudflap \
+	--disable-libmpx --disable-libmudflap \
+	--disable-libsanitizer \
 	--enable-tls --enable-initfini-array \
- 	--enable-libstdcxx-filesystem-ts \
- 	--enable-libstdcxx-time=rt \
- 	\
+	--enable-libstdcxx-filesystem-ts \
+	--enable-libstdcxx-time=rt \
+	\
 	AR_FOR_TARGET=$(CROSS_PREFIX)ar \
 	AS_FOR_TARGET=$(CROSS_PREFIX)as \
 	LD_FOR_TARGET=$(CROSS_PREFIX)ld \
@@ -148,6 +150,7 @@ $(MUSL_DIR)/.install: $(MUSL_DIR)/.build
 	cd $(@D) && $(MAKE) install $(MUSL_VARS)
     # make the important abi/bits headers available to
     # the kernel by linking them into the include path
+	mkdir -p $(TOOL_ROOT)/include
 	ln -sfn $(MUSL_PREFIX)/include/bits $(TOOL_ROOT)/include/bits
 	ln -sf $(MUSL_PREFIX)/include/features.h $(TOOL_ROOT)/include/features.h
 	ln -sf $(MUSL_PREFIX)/include/limits.h $(TOOL_ROOT)/include/limits.h
@@ -211,7 +214,7 @@ LIBDWARF_CONFIG = \
 	PKG_CONFIG=
 
 $(LIBDWARF_SRC_DIR)/.setup: | $(LIBDWARF_SRC_DIR)
-	cd $(@D) && patch -d . < $(PROJECT_DIR)/toolchain/patches/libdwarf.patch
+	cd $(@D) && patch -p 1 -d . < $(PROJECT_DIR)/toolchain/patches/libdwarf.patch
 	@touch $@
 
 $(LIBDWARF_DIR)/.configure: $(LIBDWARF_SRC_DIR)/.setup

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -74,15 +74,14 @@ GCC_PREFIX = $(TOOL_ROOT)
 
 GCC_CONFIG = --enable-languages=c,c++ \
 	--target=$(TOOLCHAIN) \
-	--prefix=$(GCC_PREFIX) \
-	--srcdir=$(GCC_SRC_DIR) \
-	--with-sysroot=$(TOOL_ROOT) \
-	--with-build-sysroot=$(TOOL_ROOT) \
+    --prefix=$(GCC_PREFIX) \
+    --srcdir=$(GCC_SRC_DIR) \
+    --with-sysroot=$(TOOL_ROOT) \
+    --with-build-sysroot=$(TOOL_ROOT) \
 	--disable-shared \
 	--disable-bootstrap --disable-multilib \
 	--disable-libmpx --disable-libmudflap \
-	--disable-libsanitizer --disable-libstdcxx \
-	--disable-libgomp --disable-libssp\
+	--disable-libsanitizer \
 	--enable-tls --enable-initfini-array \
 	--enable-libstdcxx-filesystem-ts \
 	--enable-libstdcxx-time=rt \

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -11,12 +11,23 @@ LIBDWARF_DIR = $(BUILD_DIR)/libdwarf/build
 
 
 .NOTPARALLEL:
-all: binutils gcc musl libdwarf
+all: binutils gcc musl libdwarf musl-shared
+
+clean:
+	rm -rf $(BINUTILS_DIR)
+	rm -rf $(GCC_DIR)
+	rm -rf $(MUSL_DIR)
+	rm -rf $(PKGCONFIG_DIR)
+	rm -rf $(LIBDWARF_DIR)
+	rm -rf $(BUILD_DIR)/toolchain
+	rm -f $(GCC_SRC_DIR)/.setup
+	rm -f $(LIBDWARF_SRC_DIR)/.setup
 
 binutils: $(BINUTILS_DIR)/.install
 gcc: $(GCC_DIR)/.install
 musl: $(MUSL_DIR)/.install
 musl-headers: $(MUSL_DIR)/.install-headers
+musl-shared: $(MUSL_DIR)/.install-shared
 pkg-config: $(PKGCONFIG_DIR)/.install
 libdwarf: $(LIBDWARF_DIR)/.install
 
@@ -47,9 +58,9 @@ $(BINUTILS_DIR)/.build: $(BINUTILS_DIR)/.configure
 	cd $(@D) && $(MAKE)
 	@touch $@
 
-.PHONY: $(BINUTILS_DIR)/.install
 $(BINUTILS_DIR)/.install: $(BINUTILS_DIR)/.build
 	cd $(@D) && $(MAKE) install
+	@touch $@
 
 #
 # gcc
@@ -67,10 +78,11 @@ GCC_CONFIG = --enable-languages=c,c++ \
 	--srcdir=$(GCC_SRC_DIR) \
 	--with-sysroot=$(TOOL_ROOT) \
 	--with-build-sysroot=$(TOOL_ROOT) \
-	--enable-shared \
+	--disable-shared \
 	--disable-bootstrap --disable-multilib \
 	--disable-libmpx --disable-libmudflap \
-	--disable-libsanitizer \
+	--disable-libsanitizer --disable-libstdcxx \
+	--disable-libgomp --disable-libssp\
 	--enable-tls --enable-initfini-array \
 	--enable-libstdcxx-filesystem-ts \
 	--enable-libstdcxx-time=rt \
@@ -88,10 +100,9 @@ GCC_CONFIG = --enable-languages=c,c++ \
 $(GCC_SRC_DIR)/.setup: | $(GCC_SRC_DIR)
 	cd $(@D) && ./contrib/download_prerequisites
 	cd $(@D) && autoconf
-	cd $(@D) && autoconf
 	@touch $@
 
-$(GCC_DIR)/.configure: $(GCC_SRC_DIR)/.setup
+$(GCC_DIR)/.configure: $(GCC_SRC_DIR)/.setup $(BINUTILS_DIR)/.install
 	mkdir -p $(@D)
 	cd $(@D) && $(GCC_SRC_DIR)/configure $(GCC_CONFIG)
 	@touch $@
@@ -101,17 +112,17 @@ $(GCC_DIR)/.gcc-only: $(GCC_DIR)/.configure
 	cd $(@D) && $(MAKE) all-gcc
 	@touch $@
 
-$(GCC_DIR)/.libgcc: $(GCC_DIR)/.gcc-only | $(MUSL_DIR)/.install-headers
+$(GCC_DIR)/.libgcc: $(MUSL_DIR)/.install
 	cd $(@D) && $(MAKE) enable_shared=no all-target-libgcc
 	@touch $@
 
-$(GCC_DIR)/.build: $(GCC_DIR)/.libgcc | $(MUSL_DIR)/.install
+$(GCC_DIR)/.build: $(GCC_DIR)/.libgcc $(MUSL_DIR)/.install
 	cd $(@D) && $(MAKE)
 	@touch $@
 
-.PHONY: $(GCC_DIR)/.install
 $(GCC_DIR)/.install: $(GCC_DIR)/.build
 	cd $(@D) && $(MAKE) install-gcc install-target-libgcc
+	@touch $@
 
 #
 # musl
@@ -120,11 +131,15 @@ $(GCC_DIR)/.install: $(GCC_DIR)/.build
 MUSL_SRC_DIR = $(PROJECT_DIR)/third-party/musl
 MUSL_PREFIX = $(TOOL_ROOT)/usr
 
+# We need to make sure that --disable-shared
+# is set in order to bootstrap libgcc.a for the
+# first time.
 MUSL_CONFIG = \
 	--target=$(TOOLCHAIN) \
 	--prefix= \
 	--srcdir=$(MUSL_SRC_DIR) \
 	--enable-debug \
+	--disable-shared \
 	\
 	CFLAGS="-g -O0" \
 	CC="$(GCC_DIR)/gcc/xgcc -B $(GCC_DIR)/gcc" \
@@ -135,7 +150,7 @@ MUSL_VARS = \
 	RANLIB=$(CROSS_PREFIX)ranlib \
 	LDSO_PATHNAME=/lib/ld-musl-$(ARCH).so.1
 
-$(MUSL_DIR)/.configure: | $(MUSL_SRC_DIR)
+$(MUSL_DIR)/.configure: $(GCC_DIR)/.gcc-only | $(MUSL_SRC_DIR)
 	mkdir -p $(@D)
 	cd $(@D) && $(MUSL_SRC_DIR)/configure $(MUSL_CONFIG)
 	@touch $@
@@ -144,7 +159,6 @@ $(MUSL_DIR)/.build: $(MUSL_DIR)/.configure
 	cd $(@D) && $(MAKE) $(MUSL_VARS)
 	@touch $@
 
-.PHONY: $(MUSL_DIR)/.install
 $(MUSL_DIR)/.install: export DESTDIR = $(MUSL_PREFIX)
 $(MUSL_DIR)/.install: $(MUSL_DIR)/.build
 	cd $(@D) && $(MAKE) install $(MUSL_VARS)
@@ -154,12 +168,46 @@ $(MUSL_DIR)/.install: $(MUSL_DIR)/.build
 	ln -sfn $(MUSL_PREFIX)/include/bits $(TOOL_ROOT)/include/bits
 	ln -sf $(MUSL_PREFIX)/include/features.h $(TOOL_ROOT)/include/features.h
 	ln -sf $(MUSL_PREFIX)/include/limits.h $(TOOL_ROOT)/include/limits.h
-
+	@touch $@
 
 .PHONY: $(MUSL_DIR)/.install-headers
 $(MUSL_DIR)/.install-headers: export DESTDIR = $(MUSL_PREFIX)
 $(MUSL_DIR)/.install-headers: $(MUSL_DIR)/.configure
 	cd $(@D) && $(MAKE) install-headers
+# We need to build MUSL again as a shared object
+# in order to make sure we have -fPIC enabled for the
+# final kernel.
+MUSL_CONFIG_SHARED = \
+	--target=$(TOOLCHAIN) \
+	--prefix= \
+	--srcdir=$(MUSL_SRC_DIR) \
+	--enable-debug \
+	--enable-shared \
+	\
+	CFLAGS="-g -O0" \
+	CC="$(GCC_DIR)/gcc/xgcc -B $(GCC_DIR)/gcc" \
+	LIBCC="$(GCC_DIR)/$(TOOLCHAIN)/libgcc/libgcc.a"
+
+$(MUSL_DIR)/.configure-shared: $(GCC_DIR)/.install | $(MUSL_SRC_DIR)
+	mkdir -p $(@D)
+	cd $(@D) && $(MUSL_SRC_DIR)/configure $(MUSL_CONFIG_SHARED)
+	cd $(@D) && $(MAKE) $(MUSL_VARS) clean
+	@touch $@
+
+$(MUSL_DIR)/.build-shared: $(MUSL_DIR)/.configure-shared
+	cd $(@D) && $(MAKE) $(MUSL_VARS)
+	@touch $@
+
+$(MUSL_DIR)/.install-shared: export DESTDIR = $(MUSL_PREFIX)
+$(MUSL_DIR)/.install-shared: $(MUSL_DIR)/.build-shared
+	cd $(@D) && $(MAKE) install $(MUSL_VARS)
+    # make the important abi/bits headers available to
+    # the kernel by linking them into the include path
+	mkdir -p $(TOOL_ROOT)/include
+	ln -sfn $(MUSL_PREFIX)/include/bits $(TOOL_ROOT)/include/bits
+	ln -sf $(MUSL_PREFIX)/include/features.h $(TOOL_ROOT)/include/features.h
+	ln -sf $(MUSL_PREFIX)/include/limits.h $(TOOL_ROOT)/include/limits.h
+	@touch $@
 
 #
 # pkg-config
@@ -187,6 +235,7 @@ $(PKGCONFIG_DIR)/.build: $(PKGCONFIG_DIR)/.configure
 
 $(PKGCONFIG_DIR)/.install: $(PKGCONFIG_DIR)/.build
 	cd $(@D) && $(MAKE) install
+	@touch $@
 
 #
 # libdwarf
@@ -226,9 +275,9 @@ $(LIBDWARF_DIR)/.build: $(LIBDWARF_DIR)/.configure
 	cd $(@D) && $(MAKE)
 	@touch $@
 
-.PHONY: $(LIBDWARF_DIR)/.install
 $(LIBDWARF_DIR)/.install: $(LIBDWARF_DIR)/.build
 	cd $(@D) && $(MAKE) install
+	@touch $@
 
 #
 # Support rules for fetching sources
@@ -258,9 +307,9 @@ $(BUILD_DIR)/%/src: $(BUILD_DIR)/%/$$(archive)
 .PRECIOUS: $(BUILD_DIR)/%.tar.gz
 $(BUILD_DIR)/%.tar.gz:
 	@mkdir -p $(@D)
-	wget -nc $(source) -O $@
+	wget -nc $(source) -o - -O $@
 
 .PRECIOUS: $(BUILD_DIR)/%.tar.xz
 $(BUILD_DIR)/%.tar.xz:
 	@mkdir -p $(@D)
-	wget -nc $(source) -O $@
+	wget -nc $(source) -o - -O $@

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -144,6 +144,20 @@ MUSL_CONFIG = \
 	CC="$(GCC_DIR)/gcc/xgcc -B $(GCC_DIR)/gcc" \
 	LIBCC="$(GCC_DIR)/$(TOOLCHAIN)/libgcc/libgcc.a"
 
+# We need to build MUSL again as a shared object
+# in order to make sure we have -fPIC enabled for the
+# final kernel.
+MUSL_CONFIG_SHARED = \
+	--target=$(TOOLCHAIN) \
+	--prefix= \
+	--srcdir=$(MUSL_SRC_DIR) \
+	--enable-debug \
+	--enable-shared \
+	\
+	CFLAGS="-g -O0" \
+	CC="$(GCC_DIR)/gcc/xgcc -B $(GCC_DIR)/gcc" \
+	LIBCC="$(GCC_DIR)/$(TOOLCHAIN)/libgcc/libgcc.a"
+
 MUSL_VARS = \
 	AR=$(CROSS_PREFIX)ar \
 	RANLIB=$(CROSS_PREFIX)ranlib \
@@ -173,19 +187,6 @@ $(MUSL_DIR)/.install: $(MUSL_DIR)/.build
 $(MUSL_DIR)/.install-headers: export DESTDIR = $(MUSL_PREFIX)
 $(MUSL_DIR)/.install-headers: $(MUSL_DIR)/.configure
 	cd $(@D) && $(MAKE) install-headers
-# We need to build MUSL again as a shared object
-# in order to make sure we have -fPIC enabled for the
-# final kernel.
-MUSL_CONFIG_SHARED = \
-	--target=$(TOOLCHAIN) \
-	--prefix= \
-	--srcdir=$(MUSL_SRC_DIR) \
-	--enable-debug \
-	--enable-shared \
-	\
-	CFLAGS="-g -O0" \
-	CC="$(GCC_DIR)/gcc/xgcc -B $(GCC_DIR)/gcc" \
-	LIBCC="$(GCC_DIR)/$(TOOLCHAIN)/libgcc/libgcc.a"
 
 $(MUSL_DIR)/.configure-shared: $(GCC_DIR)/.install | $(MUSL_SRC_DIR)
 	mkdir -p $(@D)

--- a/toolchain/edk2.sh
+++ b/toolchain/edk2.sh
@@ -71,15 +71,6 @@ toolchain::edk2::build() {
   mkdir -p ${build_dir}
 
   export WORKSPACE="${edk2_dir}"
-  if [ ! -d ${edk2_dir} ]; then
-    git clone --depth 1 -c advice.detachedHead=false --branch ${EDK2_VERSION} https://github.com/tianocore/edk2.git ${edk2_dir}
-    pushd ${edk2_dir}
-      git submodule update --init
-      patch -p1 -d . < ${PROJECT_DIR}/toolchain/patches/edk2.patch
-      . edksetup.sh
-      CXX=llvm toolchain::util::make_build -C BaseTools
-    popd
-  fi
 
   local arch=""
   local package=""
@@ -115,6 +106,15 @@ toolchain::edk2::build() {
       ;;
   esac
   shift 2
+
+  if [ ! -d ${edk2_dir} ]; then
+    git clone --depth 1 -c advice.detachedHead=false --branch ${EDK2_VERSION} https://github.com/tianocore/edk2.git ${edk2_dir}
+    pushd ${edk2_dir}
+      git submodule update --init
+      patch -p1 -d . < ${PROJECT_DIR}/toolchain/patches/edk2.patch
+      (. edksetup.sh; CXX=llvm make -C BaseTools)
+    popd
+  fi
 
   if [[ ${package_name} =~ loader(-lst)? ]]; then
     echo "copying bootloader sources"

--- a/toolchain/patches/edk2.patch
+++ b/toolchain/patches/edk2.patch
@@ -33,3 +33,37 @@ index f2bb624..8d03507 100755
  
  ###########################
  # CLANGPDB IA32 definitions
+diff --git a/BaseTools/Source/C/Makefiles/header.makefile b/BaseTools/Source/C/Makefiles/header.makefile
+index 0df728f..8eb9fb0 100644
+--- a/BaseTools/Source/C/Makefiles/header.makefile
++++ b/BaseTools/Source/C/Makefiles/header.makefile
+@@ -92,14 +92,14 @@ BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -fwrapv \
+ -Wno-unused-result -nostdlib -g
+ else
+ BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -fwrapv \
+--fno-delete-null-pointer-checks -Wall -Werror \
++-fno-delete-null-pointer-checks -Wall -Werror -Wno-error=use-after-free -Wno-error=dangling-pointer= \
+ -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-restrict \
+ -Wno-unused-result -nostdlib -g
+ endif
+ endif
+ ifeq ($(CXX), llvm)
+ BUILD_LFLAGS =
+-BUILD_CXXFLAGS = -Wno-deprecated-register -Wno-unused-result
++BUILD_CXXFLAGS = -Wno-deprecated-register -Wno-register -Wno-unused-result
+ else
+ BUILD_LFLAGS =
+ BUILD_CXXFLAGS = -Wno-unused-result
+diff --git a/BaseTools/Source/C/VfrCompile/GNUmakefile b/BaseTools/Source/C/VfrCompile/GNUmakefile
+index fc32994..dcbf192 100644
+--- a/BaseTools/Source/C/VfrCompile/GNUmakefile
++++ b/BaseTools/Source/C/VfrCompile/GNUmakefile
+@@ -17,7 +17,7 @@ TOOL_INCLUDE = -I Pccts/h
+ OBJECTS = AParser.o DLexerBase.o ATokenBuffer.o EfiVfrParser.o VfrLexer.o VfrSyntax.o \
+           VfrFormPkg.o VfrError.o VfrUtilityLib.o VfrCompiler.o
+ ifeq ($(CXX), llvm)
+-VFR_CPPFLAGS = -Wno-deprecated-register -DPCCTS_USE_NAMESPACE_STD $(BUILD_CPPFLAGS)
++VFR_CPPFLAGS = -Wno-deprecated-register -Wno-register -DPCCTS_USE_NAMESPACE_STD $(BUILD_CPPFLAGS)
+ else
+ VFR_CPPFLAGS = -DPCCTS_USE_NAMESPACE_STD $(BUILD_CPPFLAGS)
+ endif

--- a/usr.bin/doom/Makefile
+++ b/usr.bin/doom/Makefile
@@ -23,8 +23,8 @@ SRCS_DOOM = dummy.c am_map.c doomdef.c doomstat.c dstrings.c d_event.c d_items.c
 SRC_DOOM_PATHS = $(SRCS_DOOM:%.c=$(SOURCE_PATH)/%.c)
 OBJS = $(SRCS:%.c=$(OBJ_DIR)/%.c.o) $(SRC_DOOM_PATHS:$(SOURCE_PATH)/%.c=$(SOURCE_PATH)/%.c.o)
 
-DOOMGENERIC_URL = https://github.com/aar10n/doomgeneric/archive/refs/heads/$(VERSION).zip
-DOOMGENERIC_ARCHIVE = doomgeneric-$(VERSION).zip
+DOOMGENERIC_URL = https://github.com/aar10n/doomgeneric/archive/refs/heads/$(VERSION).tar.gz
+DOOMGENERIC_ARCHIVE = doomgeneric-$(VERSION).tar.gz
 
 .DEFAULT_GOAL := install
 
@@ -38,7 +38,7 @@ download:
 	fi
 	@if [ ! -d "$(SOURCE_PATH)" ]; then \
 		echo "Extracting doomgeneric..."; \
-		cd $(OBJ_DIR) && unzip $(DOOMGENERIC_ARCHIVE); \
+		cd $(OBJ_DIR) && tar -xf $(DOOMGENERIC_ARCHIVE); \
 		mv $(OBJ_DIR)/doomgeneric-$(VERSION)/doomgeneric $(SOURCE_PATH); \
 		rm -rf $(OBJ_DIR)/doomgeneric-$(VERSION); \
 	fi

--- a/usr.bin/doom/Makefile
+++ b/usr.bin/doom/Makefile
@@ -24,7 +24,7 @@ SRC_DOOM_PATHS = $(SRCS_DOOM:%.c=$(SOURCE_PATH)/%.c)
 OBJS = $(SRCS:%.c=$(OBJ_DIR)/%.c.o) $(SRC_DOOM_PATHS:$(SOURCE_PATH)/%.c=$(SOURCE_PATH)/%.c.o)
 
 DOOMGENERIC_URL = https://github.com/aar10n/doomgeneric/archive/refs/heads/$(VERSION).zip
-DOOMGENERIC_ARCHIVE = doomgeneric-$(VERSION).tar.gz
+DOOMGENERIC_ARCHIVE = doomgeneric-$(VERSION).zip
 
 .DEFAULT_GOAL := install
 
@@ -38,7 +38,7 @@ download:
 	fi
 	@if [ ! -d "$(SOURCE_PATH)" ]; then \
 		echo "Extracting doomgeneric..."; \
-		cd $(OBJ_DIR) && tar -xf $(DOOMGENERIC_ARCHIVE); \
+		cd $(OBJ_DIR) && unzip $(DOOMGENERIC_ARCHIVE); \
 		mv $(OBJ_DIR)/doomgeneric-$(VERSION)/doomgeneric $(SOURCE_PATH); \
 		rm -rf $(OBJ_DIR)/doomgeneric-$(VERSION); \
 	fi


### PR DESCRIPTION
This PR is intended to address some bootstrapping problems when compiling the toolchain and dependencies against clang-18.1.3 on an Ubuntu 24.04.2 LTS distribution.  A few issues are addressed here:
* clang gives an error in boot/Memory.c when building edk2 because placing a variable declaration after a jump label is a C23 extension.  Moving the variable declaration before the label addresses this warning (error because -Werror is set during the edk2 build).
* The iasl command-line (distributed in acpica-tools) is required to build "make ovmf", so should be included in the dependency check for the configure script.
* GCC bootstrapping with musl requires first that musl is compiled without shared libraries enabled so that libgcc can compile, but later the full "musl" shared library must be built with -fPIC after GCC finishes bootstrapping.  This requires that the initial 'xgcc' compiler is built first, followed by musl is built first without shared libraries, followed by libgcc, followed by 'musl' with shared libraries enabled.  This required a slight reworking of dependencies and order for the "toolchain/Makefile".
* Not strictly part of the issues, but for convenience in debugging the toolchain, some of the ".PHONY" targets were changed to be real targets so that the toolchain phases can easily be built one step at a time without rebuilding prior parts of the toolchain.
* The "edk2" package, when built with some versions of clang are more pedantic and produced warnings (with -Werror) on some register declarations of variables in C.
* In the 'edk2.sh' script, the 'edksetup.sh' script is sourced.  When this happens, care must be taken that the command-line arguments have been shifted off before the script is sourced.  For that reason, the location of the one of the usages of ". edksetup.sh' had to be moved down a few lines to below the point where the command-line arguments had been handled and 'shifted' off the argument stack.
